### PR TITLE
[MGDAPI-2656] update e2e test config for sts auth

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -1527,7 +1527,7 @@ func getInstallation() (*rhmiv1alpha1.RHMI, error) {
 // 3.	parameter exists and value is empty
 // 4.	parameter does not exists
 func validateAddOnStsRoleArnParameterPattern(client k8sclient.Client, namespace string) (bool, error) {
-	stsRoleArn, err := sts.GetStsRoleArn(context.TODO(), client, namespace)
+	stsRoleArn, err := sts.GetSTSRoleARN(context.TODO(), client, namespace)
 	if err != nil {
 		return false, fmt.Errorf("failed while retrieving addon parameter: %v", err)
 	}

--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -151,7 +151,7 @@ func Test_validateAddOnStsRoleArnParameterPattern(t *testing.T) {
 		{
 			name: "test: role arn empty",
 			args: args{
-				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.AddonStsArnParameterName: []byte("")})),
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("")})),
 				namespace: namespace,
 			},
 			wantErr: true,
@@ -160,7 +160,7 @@ func Test_validateAddOnStsRoleArnParameterPattern(t *testing.T) {
 		{
 			name: "test: role arn regex not match",
 			args: args{
-				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.AddonStsArnParameterName: []byte("notAnARN")})),
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("notAnARN")})),
 				namespace: namespace,
 			},
 			wantErr: true,
@@ -169,7 +169,7 @@ func Test_validateAddOnStsRoleArnParameterPattern(t *testing.T) {
 		{
 			name: "test: role arn regex match",
 			args: args{
-				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.AddonStsArnParameterName: []byte("arn:aws:iam::123456789012:role/12345")})),
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("arn:aws:iam::123456789012:role/12345")})),
 				namespace: namespace,
 			},
 			wantErr: false,
@@ -178,7 +178,7 @@ func Test_validateAddOnStsRoleArnParameterPattern(t *testing.T) {
 		{
 			name: "test: role arn regex match for AWS GovCloud (US) Regions",
 			args: args{
-				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.AddonStsArnParameterName: []byte("arn:aws-us-gov:iam::123456789012:role/12345")})),
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("arn:aws-us-gov:iam::123456789012:role/12345")})),
 				namespace: namespace,
 			},
 			wantErr: false,

--- a/pkg/products/cloudresources/reconciler_test.go
+++ b/pkg/products/cloudresources/reconciler_test.go
@@ -303,7 +303,7 @@ func TestReconciler_createSTSArnSecret(t *testing.T) {
 						Namespace: defaultInstallationNamespace,
 					},
 					Data: map[string][]byte{
-						sts.AddonStsArnParameterName: []byte("arn:aws:iam::123456789012:role/12345"),
+						sts.RoleArnParameterName: []byte("arn:aws:iam::123456789012:role/12345"),
 					},
 				}),
 			},
@@ -321,13 +321,13 @@ func TestReconciler_createSTSArnSecret(t *testing.T) {
 				Reconciler:    tt.fields.Reconciler,
 				recorder:      tt.fields.recorder,
 			}
-			got, err := r.createSTSArnSecret(tt.args.ctx, tt.args.client, tt.args.operatorNamespace)
+			got, err := r.createSTSARNSecret(tt.args.ctx, tt.args.client, tt.args.operatorNamespace)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("createSTSArnSecret() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("createSTSARNSecret() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("createSTSArnSecret() got = %v, want %v", got, tt.want)
+				t.Errorf("createSTSARNSecret() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2656

# What
Currently, e2e tests are using AWS credentials from the "aws-creds" Secret in the kube-system namespace ([relevant code](https://github.com/integr8ly/integreatly-operator/blob/b23b07ac190c4b0929786065816ff73fec3ae476/test/functional/aws_shared_functions.go#L228-L241)).
These credentials are not available on a STS cluster.

# Verification steps
- Provision or borrow an STS ROSA cluster
- Create the RHOAM role on the AWS account if needed (https://github.com/integr8ly/delorean/blob/master/make/ocm.mk#L78-L88)
- oc login to the rosa cluster
- Prepare the cluster with addon secret with the ROLE_ARN to install locally
```
export INSTALLATION_TYPE=managed-api
# ROLE_ARN could be different if using a different account or role name
ROLE_ARN="arn:aws:iam::408612754352:role/rhoam_role" make cluster/prepare/local
# Use aws resources for installation
USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
```
- Install RHOAM
```
make code/run
```
- Run any/all e2e test to verify sts authentication is working and test/s pass
```
make test/e2e/single TEST=F04
make test/functional
```